### PR TITLE
Pass all command options to jasmine

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,6 @@ if (configJSON) {
   initReporters(config);
 }
 
-const commandOptions = process.argv.slice(2).filter((option) => option.indexOf(configPath as string) >= 0);
+const commandOptions = process.argv.slice(2);
 
 command.run(jasmine, commandOptions);


### PR DESCRIPTION
As far as i understand this, the original code prevents me from passing command options to underlying Jasmine. As i want to use the IdeaJasmine plugin for PhpStorm, I need to pass the command option "--reporter=/Users/roman/Library/Application Support/JetBrains/PhpStorm2020.3/plugins/IdeaJasmine/lib/intellij_reporter.js". I hope this does not conflict with other importand needs. If so please tell me, so i can sharpen the PR.

By the way thank you very much for maintaining the jasmine-ts repo 👍 :-)